### PR TITLE
Bump jsch from 0.1.44-1 to 0.1.54

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -565,7 +565,7 @@
 		<dependency>
 			<groupId>com.jcraft</groupId>
 			<artifactId>jsch</artifactId>
-			<version>0.1.44-1</version>
+			<version>0.1.54</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-dbcp</groupId>


### PR DESCRIPTION
Bumps jsch from 0.1.44-1 to 0.1.54.

---
updated-dependencies:
- dependency-name: com.jcraft:jsch dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>