### PR TITLE
Bump solr-core from 1.4.0 to 8.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
 		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-core</artifactId>
-			<version>1.4.0</version>
+			<version>8.8.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>woodstox</groupId>


### PR DESCRIPTION
Bumps solr-core from 1.4.0 to 8.8.2.

Signed-off-by: dependabot[bot] <support@github.com>