### PR TITLE
Bump jasypt from 1.9.0 to 1.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -609,7 +609,7 @@
 		<dependency>
 			<groupId>org.jasypt</groupId>
 			<artifactId>jasypt</artifactId>
-			<version>1.9.0</version>
+			<version>1.9.2</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Bumps jasypt from 1.9.0 to 1.9.2.

---
updated-dependencies:
- dependency-name: org.jasypt:jasypt dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>