### PR TITLE
Bump resteasy-jaxrs from 2.2.1.GA to 3.0.11.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -658,7 +658,7 @@
          <dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-jaxrs</artifactId>
-			<version>2.2.1.GA</version>
+			<version>3.0.11.Final</version>
 		</dependency>
 		
 		<dependency>


### PR DESCRIPTION
Bumps resteasy-jaxrs from 2.2.1.GA to 3.0.11.Final.

---
updated-dependencies:
- dependency-name: org.jboss.resteasy:resteasy-jaxrs dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>